### PR TITLE
Fix: Spotlight Text Color Issue #1609

### DIFF
--- a/src/components/animated/_spotlight.less
+++ b/src/components/animated/_spotlight.less
@@ -27,7 +27,7 @@
 }
 .sbtn.spotlight-btn {
   position: relative;
-  color: @darkText;
+  color: #fff;
   background-color: transparent;
   overflow: visible !important;
   outline: none;


### PR DESCRIPTION


<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->
Fix: In dark mode, the text color is now white before the animation starts.
<!-- Specify the issue it relates to, if any --->
Issue: Spotlight button's text color in dark mode #1609
